### PR TITLE
Add a RPM spec file.

### DIFF
--- a/libopkele.spec
+++ b/libopkele.spec
@@ -2,7 +2,7 @@ Summary: a c++ implementation of an OpenID decentralized identity system
 Name: libopkele
 Version: 2.0.4
 Release: 1
-License: BSD
+License: MIT
 URL: http://kin.klever.net/libopkele/
 Source0: %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-root

--- a/libopkele.spec
+++ b/libopkele.spec
@@ -2,11 +2,15 @@ Summary: a c++ implementation of an OpenID decentralized identity system
 Name: libopkele
 Version: 2.0.4
 Release: 1
-License: GPL
+License: BSD
 URL: http://kin.klever.net/libopkele/
 Source0: %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-root
-BuildRequires: gcc-c++ openssl-devel libcurl-devel libtidy-devel expat-devel
+BuildRequires: expat-devel
+BuildRequires: gcc-c++
+BuildRequires: libcurl-devel
+BuildRequires: libtidy-devel
+BuildRequires: openssl-devel
 
 %description
 libopkele is a c++ implementation of an OpenID decentralized identity system.
@@ -18,23 +22,21 @@ interaction to the implementor.
 
 %build
 %configure
-
 make %{?_smp_mflags}
 
 %install
 rm -rf %{buildroot}
-%make_install
+make install DESTDIR=%{buildroot}
 
 %clean
 rm -rf %{buildroot}
 
-%post
-ldconfig
+%post -p /sbin/ldconfig
 
-%postun
-ldconfig
+%postun -p /sbin/ldconfig
 
 %files
+%defattr(-,root,root,-)
 %{_libdir}/libopkele.a
 %{_libdir}/libopkele.la
 %{_libdir}/libopkele.so
@@ -44,7 +46,7 @@ ldconfig
 
 %package devel
 Summary: Development headers for libopkele
-Requires: %{name} = %{version}
+Requires: %{name}%{?_isa} = %{version}-%{release}
 
 %description devel
 libopkele is a c++ implementation of an OpenID decentralized identity system.
@@ -52,6 +54,7 @@ It provides OpenID protocol handling, leaving authentication and user
 interaction to the implementor.
 
 %files devel
+%defattr(-,root,root,-)
 %dir %{_includedir}/opkele
 %{_includedir}/opkele/acconfig.h
 %{_includedir}/opkele/association.h

--- a/libopkele.spec
+++ b/libopkele.spec
@@ -1,0 +1,73 @@
+Summary: a c++ implementation of an OpenID decentralized identity system
+Name: libopkele
+Version: 2.0.4
+Release: 1
+License: GPL
+URL: http://kin.klever.net/libopkele/
+Source0: %{name}-%{version}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-root
+BuildRequires: gcc-c++ openssl-devel libcurl-devel libtidy-devel
+
+%description
+libopkele is a c++ implementation of an OpenID decentralized identity system.
+It provides OpenID protocol handling, leaving authentication and user
+interaction to the implementor.
+
+%prep
+%setup -q
+
+%build
+%configure
+
+make %{?_smp_mflags}
+
+%install
+rm -rf %{buildroot}
+%make_install
+
+%clean
+rm -rf %{buildroot}
+
+%post
+ldconfig
+
+%postun
+ldconfig
+
+%files
+%{_libdir}/libopkele.a
+%{_libdir}/libopkele.la
+%{_libdir}/libopkele.so
+%{_libdir}/libopkele.so.3
+%{_libdir}/libopkele.so.3.0.0
+%{_libdir}/pkgconfig/libopkele.pc
+
+%package devel
+Summary: Development headers for libopkele
+Requires: %{name} = %{version}
+
+%description devel
+libopkele is a c++ implementation of an OpenID decentralized identity system.
+It provides OpenID protocol handling, leaving authentication and user
+interaction to the implementor.
+
+%files devel
+%dir %{_includedir}/opkele
+%{_includedir}/opkele/acconfig.h
+%{_includedir}/opkele/association.h
+%{_includedir}/opkele/ax.h
+%{_includedir}/opkele/basic_op.h
+%{_includedir}/opkele/basic_rp.h
+%{_includedir}/opkele/exception.h
+%{_includedir}/opkele/extension.h
+%{_includedir}/opkele/extension_chain.h
+%{_includedir}/opkele/iterator.h
+%{_includedir}/opkele/oauth_ext.h
+%{_includedir}/opkele/opkele-config.h
+%{_includedir}/opkele/prequeue_rp.h
+%{_includedir}/opkele/sreg.h
+%{_includedir}/opkele/tr1-mem.h
+%{_includedir}/opkele/types.h
+%{_includedir}/opkele/uris.h
+%{_includedir}/opkele/util.h
+%{_includedir}/opkele/verify_op.h

--- a/libopkele.spec
+++ b/libopkele.spec
@@ -6,7 +6,7 @@ License: GPL
 URL: http://kin.klever.net/libopkele/
 Source0: %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-root
-BuildRequires: gcc-c++ openssl-devel libcurl-devel libtidy-devel
+BuildRequires: gcc-c++ openssl-devel libcurl-devel libtidy-devel expat-devel
 
 %description
 libopkele is a c++ implementation of an OpenID decentralized identity system.


### PR DESCRIPTION
Adding a spec file for building RPMs. Tested under Scientific Linux 6 in a Koji build system.
